### PR TITLE
Create dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    allow:
+      - dependency-type: "all"
+    open-pull-requests-limit: 20


### PR DESCRIPTION
Tells Dependabot to open PRs for [version updates even when not for security patches](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/about-dependabot-version-updates).

This may be too often, but let's start daily and see how many updates we get.