### PR TITLE
Set macos-12 for CI pytest

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -8,11 +8,11 @@ jobs:
     
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-12, windows-latest]
         include:
           - os: ubuntu-latest
             poetry: ~/.local/bin/poetry
-          - os: macos-latest
+          - os: macos-12
             poetry: ~/.local/bin/poetry
           - os: windows-latest
             poetry: $APPDATA/Python/Scripts/poetry


### PR DESCRIPTION
macos-latest is macos-11 but will be macos-12 soon:

https://github.com/actions/runner-images/issues/6384