### PR TITLE
Set a short timeout in CI for pytest itself

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -41,3 +41,4 @@ jobs:
 
       - name: Run all tests
         run: ${{ matrix.poetry }} run pytest --doctest-modules
+        timeout-minutes: 2


### PR DESCRIPTION
The setup can take a while, but running the tests should be fast.

The benefit of setting the timeout low is to avoid waiting an excessive amount of time (or manually cancelling jobs) if code cannot pass tests due to deadlock bugs.