### PR TITLE
Test on all platforms via CI even if some fail

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -7,6 +7,7 @@ jobs:
     name: Test
     
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-12, windows-latest]
         include:


### PR DESCRIPTION
Instead of canceling other platforms' tests when one fails or times out.

If there are failures or deadlocks due to platform-specific code that was not intended to be platform-specific, it can be helpful to know about that, especially when one would not think to check for it.

This is on a matrix with only one parameter that generates only 3 jobs. For future matrices that generate more jobs, fail-fast should probably be left as true.

We currently only support *all* tests, including doctests, on Python 3.11. In contrast, the non-doctests (unittest tests and, on other branches and on main in the future, pytest tests) should be able to pass on Python 3.10 and up, though we may need to fix some 3.11-specific assumptions in unittest tests to make this happen. If that is done and commands like "pytest" (without "--doctest-modules") and "unittest" are run on CI, which would probably be a separate workflow, then fail-fast should probably be kept at the default value of true for that workflow.