### PR TITLE
Have test_greetall.txt request and expect UTF-8

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -135,6 +135,7 @@
         "preimage",
         "pyproject",
         "pytest",
+        "PYTHONIOENCODING",
         "qualname",
         "quux",
         "radd",

--- a/poetry.lock
+++ b/poetry.lock
@@ -172,14 +172,14 @@ files = [
 
 [[package]]
 name = "beautifulsoup4"
-version = "4.11.1"
+version = "4.11.2"
 description = "Screen-scraping library"
 category = "dev"
 optional = false
 python-versions = ">=3.6.0"
 files = [
-    {file = "beautifulsoup4-4.11.1-py3-none-any.whl", hash = "sha256:58d5c3d29f5a36ffeb94f02f0d786cd53014cf9b3b3951d42e0080d8a9498d30"},
-    {file = "beautifulsoup4-4.11.1.tar.gz", hash = "sha256:ad9aa55b65ef2808eb405f46cf74df7fcb7044d5cbc26487f96eb2ef2e436693"},
+    {file = "beautifulsoup4-4.11.2-py3-none-any.whl", hash = "sha256:0e79446b10b3ecb499c1556f7e228a53e64a2bfcebd455f370d8927cb5b59e39"},
+    {file = "beautifulsoup4-4.11.2.tar.gz", hash = "sha256:bc4bdda6717de5a2987436fb8d72f45dc90dd856bdfd512a1314ce90349a0106"},
 ]
 
 [package.dependencies]
@@ -848,14 +848,14 @@ format-nongpl = ["fqdn", "idna", "isoduration", "jsonpointer (>1.13)", "rfc3339-
 
 [[package]]
 name = "jupyter-client"
-version = "8.0.1"
+version = "8.0.2"
 description = "Jupyter protocol implementation and client libraries"
 category = "dev"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "jupyter_client-8.0.1-py3-none-any.whl", hash = "sha256:6016b874fd1111d721bc5bee30624399e876e79e6f395d1a559e6dce9fb2e1ba"},
-    {file = "jupyter_client-8.0.1.tar.gz", hash = "sha256:3f67b1c8b7687e6db09bef10ff97669932b5e6ef6f5a8ee56d444b89022c5007"},
+    {file = "jupyter_client-8.0.2-py3-none-any.whl", hash = "sha256:c53731eb590b68839b0ce04bf46ff8c4f03278f5d9fe5c3b0f268a57cc2bd97e"},
+    {file = "jupyter_client-8.0.2.tar.gz", hash = "sha256:47ac9f586dbcff4d79387ec264faf0fdeb5f14845fa7345fd7d1e378f8096011"},
 ]
 
 [package.dependencies]
@@ -871,14 +871,14 @@ test = ["codecov", "coverage", "ipykernel (>=6.14)", "mypy", "paramiko", "pre-co
 
 [[package]]
 name = "jupyter-core"
-version = "5.1.5"
+version = "5.2.0"
 description = "Jupyter core package. A base package on which Jupyter projects rely."
 category = "dev"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "jupyter_core-5.1.5-py3-none-any.whl", hash = "sha256:83064d61bb2a9bc874e8184331c117b3778c2a7e1851f60cb00d273ceb3285ae"},
-    {file = "jupyter_core-5.1.5.tar.gz", hash = "sha256:8e54c48cde1e0c8345f64bcf9658b78044ddf02b273726cea9d9f59be4b02130"},
+    {file = "jupyter_core-5.2.0-py3-none-any.whl", hash = "sha256:4bdc2928c37f6917130c667d8b8708f20aee539d8283c6be72aabd2a4b4c83b0"},
+    {file = "jupyter_core-5.2.0.tar.gz", hash = "sha256:1407cdb4c79ee467696c04b76633fc1884015fa109323365a6372c8e890cc83f"},
 ]
 
 [package.dependencies]
@@ -917,14 +917,14 @@ test = ["click", "coverage", "pre-commit", "pytest (>=7.0)", "pytest-asyncio (>=
 
 [[package]]
 name = "jupyter-server"
-version = "2.1.0"
+version = "2.2.0"
 description = "The backend—i.e. core services, APIs, and REST endpoints—to Jupyter web applications."
 category = "dev"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "jupyter_server-2.1.0-py3-none-any.whl", hash = "sha256:90cd6f2bd0581ddd9b2dbe82026a0f4c228a1d95c86e22460efbfdfc931fcf56"},
-    {file = "jupyter_server-2.1.0.tar.gz", hash = "sha256:efaae5e4f0d5f22c7f2f2dc848635036ee74a2df02abed52d30d9d95121ad382"},
+    {file = "jupyter_server-2.2.0-py3-none-any.whl", hash = "sha256:9c79b7227a7e3974856265908da40715ab49b7014ac39478d80b07e164b5a70e"},
+    {file = "jupyter_server-2.2.0.tar.gz", hash = "sha256:f901efcb4adce2370c64dc5942be587bd181119644660a1eb123435c3cd01f95"},
 ]
 
 [package.dependencies]
@@ -2156,14 +2156,14 @@ files = [
 
 [[package]]
 name = "traitlets"
-version = "5.8.1"
+version = "5.9.0"
 description = "Traitlets Python configuration system"
 category = "dev"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "traitlets-5.8.1-py3-none-any.whl", hash = "sha256:a1ca5df6414f8b5760f7c5f256e326ee21b581742114545b462b35ffe3f04861"},
-    {file = "traitlets-5.8.1.tar.gz", hash = "sha256:32500888f5ff7bbf3b9267ea31748fa657aaf34d56d85e60f91dda7dc7f5785b"},
+    {file = "traitlets-5.9.0-py3-none-any.whl", hash = "sha256:9e6ec080259b9a5940c797d58b613b5e31441c2257b87c2e795c5228ae80d2d8"},
+    {file = "traitlets-5.9.0.tar.gz", hash = "sha256:f6cde21a9c68cf756af02035f72d5a723bf607e862e7be33ece505abf4a3bad9"},
 ]
 
 [package.extras]

--- a/tests/test_greetall.txt
+++ b/tests/test_greetall.txt
@@ -6,8 +6,15 @@ SPDX-License-Identifier: 0BSD
 TODO: Write better, more exhaustive tests, probably with pytest.
 ================================================================
 
->>> from subprocess import getstatusoutput as gso
->>> from sys import executable as py
+>>> import functools
+>>> import os
+>>> import subprocess
+>>> import sys
+
+>>> os.environ['PYTHONIOENCODING'] = 'utf-8'
+>>> gso = functools.partial(subprocess.getstatusoutput, encoding='utf-8')
+
+>>> py = sys.executable
 >>> if '"' in py:
 ...     raise Exception("""tests can't handle "'" in interpreter path""")
 


### PR DESCRIPTION
Doctests in `test_greetall.txt` use `subprocess.getstatusoutput` to run the Python interpreter via a shell, testing the behavior of greetall.py when it is run as a program. This remains the case.

But when I wrote those doctests, I accidentally wrote them in a way that implicitly assumed the Python subprocess's output encoding agreed with the encoding that `subprocess.getstatusoutput` expected. This is usually, but not always, the case.

The encoding `subprocess.getstatusoutput` expects is the encoding expected by the parent process, which calls that to run the child process. The Python subprocess's output encoding is the encoding the child process uses for `sys.stdout`, as used in `greetall.py` and any modules it uses, including implicitly via the `print` builtin. (It may be relevant that, on Windows, a shell may also affect this, since when PowerShell is used to process or display text output, it can change its encoding. Recent versions of PowerShell use UTF-8.)

At some point, this brittle situation was broken by an update, in a single scenario. The breakage might also have involved an update to VS Code, outside of which the problem never seems to occur, and/or the recent update to PowerShell (7.3.2). I'm not sure.

What broke is: Windows, with poetry (not conda/mamba), using pytest to run the doctests, and using the VS Code test runner (the "beaker") to run pytest. This seems to be the only scenario that broke. In particular, I often run all tests on Windows, in a poetry-managed environment, using pytest. In addition to my doing that manually, it is one of the ways our tests run via CI on GitHub. But in VS Code instead of by running the pytest command manually or from a script, it breaks.

Currently, poetry gives us Python 3.11.1, while conda/mamba gives us Python 3.11.0. So poetry vs. conda/mamba is probably a proxy for that distinction.

It *appears* that the cause of the mismatch, broadly speaking, was:

- On Unix-like systems, the parent process expected UTF-8 and the child process would output UTF-8. (Good.)
- On Windows, when not run via VS Code, the parent process expected Latin-1 and the child process would output Latin-1. (Good.)
- On Windows, with VS Code, under the conditions described above, the parent process expected Latin-1 but the child process would output UTF-8. (Bad.)

The way the failure manifested was that the `¡` characters in output from a Spanish greeter (see `greet.py` and `greetall.py`) were received as `Â¡` instead, causing the tests to fail.

Passing `encoding='utf-8'` to `subprocess.getstatusoutput`, without making any other change, is enough to fix the problem in VS Code. But that breaks the tests when run with the pytest command from a terminal. This is to say it replaces the bug with a reverse bug.

In any case, I think it is a bug (albeit a less severe one) for `test_greetall.txt` to assume the parent and child processes agree on encoding, even in the absence of a specific situation like this.

This pull request fixes the bug by setting the encoding in the environment the child process inherits (in `PYTHONIOENCODING`) in addition to telling `subprocess.getstatusoutput` to expect UTF-8.

*This PR comment is adapted from the commit message at 51cb5a8.*