### PR TITLE
Temporarily switch to prerelease Python extension

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -19,6 +19,7 @@
                 "eamodio.gitlens",
                 "mads-hartmann.bash-ide-vscode",
                 "mhutchie.git-graph",
+                "ms-python.python@prerelease",
                 "ms-vsliveshare.vsliveshare",
                 "stkb.rewrap",
                 "streetsidesoftware.code-spell-checker",


### PR DESCRIPTION
A bug in ms-python.python prevents the extension from loading:

https://github.com/microsoft/vscode/issues/171960

The bug has been fixed but, at this time, the fix is only in the prerelease version of the extension.

This commit switches to the prerelease version of the extension in dev containers. I plan to set it back to the stable version, once it incorporates the bugfix.