### PR TITLE
Let CodeQL install dependencies, with help

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -37,8 +37,9 @@ jobs:
     #       conditions. If possible, use a technique compatible with Windows
     #       runners, since some of our other CI workflows will run on multiple
     #       operating systems including Windows (and could then share code).
-    - name: Install poetry
-      run: curl -sSL https://raw.githubusercontent.com/EliahKagan/install.python-poetry.org/ci-repro/palgoviz/install-poetry.py | python3 -
+    # FIXME: Uncomment this (or remove it if it really is not necessary).
+    # - name: Install poetry
+    #   run: curl -sSL https://raw.githubusercontent.com/EliahKagan/install.python-poetry.org/ci-repro/palgoviz/install-poetry.py | python3 -
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -43,9 +43,6 @@ jobs:
     - name: Generate requirements.txt
       run: poetry export >requirements.txt
 
-    - name: Install library dependencies
-      run: pip install -r requirements.txt
-
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v2

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -40,9 +40,6 @@ jobs:
     - name: Install poetry
       run: curl -sSL https://raw.githubusercontent.com/EliahKagan/install.python-poetry.org/ci-repro/palgoviz/install-poetry.py | python3 -
 
-    - name: Generate requirements.txt
-      run: poetry export >requirements.txt
-
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v2

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -33,14 +33,6 @@ jobs:
       with:
         python-version: 3.11
 
-    # TODO: Print the hash of the commit, so it appears in the logs. Avoid race
-    #       conditions. If possible, use a technique compatible with Windows
-    #       runners, since some of our other CI workflows will run on multiple
-    #       operating systems including Windows (and could then share code).
-    # FIXME: Uncomment this (or remove it if it really is not necessary).
-    # - name: Install poetry
-    #   run: curl -sSL https://raw.githubusercontent.com/EliahKagan/install.python-poetry.org/ci-repro/palgoviz/install-poetry.py | python3 -
-
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v2


### PR DESCRIPTION
This only affects CI.

*Edit: The description below is true of the first commit in this PR, but subsequent commits remove more stuff CodeQL doesn't need, including not generating requirements.txt for it.*

This still uses poetry to export a requirements.txt, but omits the immediately following step of running pip to install from it. I believe a CodeQL action will try to do that itself, and that it will take care of updating the PyPA tools (pip, setuptools, and wheel) first, which I could do manually but currently am not doing at all.