### PR TITLE
Really carry name and email from host into dev container

### DIFF
--- a/.devcontainer/postCreate
+++ b/.devcontainer/postCreate
@@ -13,7 +13,7 @@
 # OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
 # PERFORMANCE OF THIS SOFTWARE.
 
-set -e
+set -eu
 
 nl() {
     printf '\n' >&2
@@ -23,17 +23,41 @@ msg() {
     printf '%s: %s\n' "$0" "$1" >&2
 }
 
+pull_in() {
+    local name="$1" value="$2"
+
+    if git config -- "$name" >/dev/null; then
+        msg "not overwriting: $name"
+    else
+        msg "applying: $name"
+        git config --global -- "$name" "$value"
+    fi
+}
+
+pull_all_in() {
+    local name value
+
+    if ! test -e "$conf_path"; then
+        return
+    fi
+
+    while read -r name value; do
+        pull_in "$name" "$value"
+    done <"$conf_path"
+}
+
 # TODO: Customize bash and zsh prompts to indicate staged and unstaged changes.
 #       Note that devcontainers-theme.show-dirty isn't enough to achieve this.
 
 nl
 msg 'Customizing global git configuration...'
+pull_all_in
 git config --global color.diff.new blue
 msg '...global git configuration customized.'
 
 nl
 msg 'Customizing fish (the friendly interactive shell)...'
-sudo chsh -s /usr/bin/fish vscode
+sudo chsh -s /usr/bin/fish "$USER"
 fish -c 'set -U __fish_git_prompt_color_cleanstate brgreen'
 fish -c 'set -U __fish_git_prompt_show_informative_status true'
 fish -c 'set -U __fish_git_prompt_showcolorhints true'

--- a/.devcontainer/postCreate
+++ b/.devcontainer/postCreate
@@ -15,6 +15,8 @@
 
 set -eu
 
+readonly conf_path='.inherited-configuration'
+
 nl() {
     printf '\n' >&2
 }


### PR DESCRIPTION
I meant https://github.com/EliahKagan/palgoviz/pull/55 to do this! But it turns out the one case where the problem this addresses usually occurs -- reopening a local folder in a dev container on Windows -- was a case I had, somehow, failed to test after making the changes here.

The bug in #55 is that, while the configuration information is properly gathered by `initialize` or `initialize.cmd`, I forgot to add the code to `postCreate` to actually *apply* the configuration!

This commit fixes `postCreate`. It also makes some unrelated small code-quality improvements in that file.