### PR TITLE
Improve quoting in pytest CI workflow

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -14,7 +14,8 @@ jobs:
           - poetry: ~/.local/bin/poetry
 
           - os: windows-latest
-            poetry: $APPDATA/Python/Scripts/poetry
+            poetry: |-
+              "$APPDATA/Python/Scripts/poetry"
 
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
In case the home directory on the Windows runner (and thus also `$APPDATA`) were somehow to have spaces or other weird characters in its path.