### PR TITLE
CI pytest with poetry, multiple Python versions

### DIFF
--- a/.github/workflows/pytest-some-tests-poetry.yml
+++ b/.github/workflows/pytest-some-tests-poetry.yml
@@ -1,0 +1,55 @@
+name: "pytest (some tests, poetry)"
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    name: Test
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        python-version: ['3.10', '3.11']
+        include:
+          - poetry: ~/.local/bin/poetry
+
+          - os: windows-latest
+            poetry: |-
+              "$APPDATA/Python/Scripts/poetry"
+
+    runs-on: ${{ matrix.os }}
+
+    defaults:
+      run:
+        shell: bash
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v3
+
+      - name: Remove poetry.lock
+        run: rm poetry.lock
+
+      - name: Substitute python version
+        run: |
+          perl -i -spwe 's/^python = "~\K[^"]+(?="$)/$pyver/' -- \
+              -pyver=${{ matrix.python-version }} pyproject.toml
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      # TODO: Print the install script commit hash and Poetry version.
+      - name: Install poetry
+        run: curl -sSL https://raw.githubusercontent.com/EliahKagan/install.python-poetry.org/ci-repro/palgoviz/install-poetry.py | python3 -
+
+      - name: Install project and test runner
+        run: ${{ matrix.poetry }} install --only=main,test
+
+      - name: Run all tests
+        run: |
+          ${{ matrix.poetry }} run \
+              pytest --ignore=tests/test_{greet,greetall}.txt
+        timeout-minutes: 2


### PR DESCRIPTION
This runs some (not all) tests on both 3.10 and 3.11.

It does not use poetry.lock (which is specific to 3.11).

This does not replace other workflows.