### PR TITLE
Fix problem where poetry won't install debugpy

### DIFF
--- a/poetry.toml
+++ b/poetry.toml
@@ -1,0 +1,2 @@
+[installer]
+modern-installation = false


### PR DESCRIPTION
`debugpy` is an indirect dependency of this project. When poetry 1.4.1 is used with the default configuration, poetry refuses to install `debugpy`, due to recognizing something wrong with the wheel.

This is the same issue (with the same dependency) as:

https://github.com/python-poetry/poetry/issues/7686

For now, I'm setting `installer.modern-installation` to `false`, per the workaround in:

https://github.com/python-poetry/poetry/issues/7686#issuecomment-1475402611