### PR TITLE
Revert "Fix problem where poetry won't install debugpy"

### DIFF
--- a/poetry.toml
+++ b/poetry.toml
@@ -1,2 +1,0 @@
-[installer]
-modern-installation = false


### PR DESCRIPTION
Reverts EliahKagan/palgoviz#88, which worked around a combination of bugs, including a bug in Poetry 1.4.1.

Poetry 1.4.2 has been released, fixing the Poetry bug, so this should no longer be needed (and it is better to get the warning about the broken dependency wheel): https://github.com/python-poetry/poetry/releases/tag/1.4.2