### PR TITLE
Upgrade dev container from Debian 11 to Debian 12

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
     "name": "palgoviz (EXPERIMENTAL dev container)",
-    "image": "mcr.microsoft.com/devcontainers/python:0-3.11-bullseye",
+    "image": "mcr.microsoft.com/devcontainers/python:0-3.11-bookworm",
     "features": {
         "ghcr.io/devcontainers/features/powershell:1": {},
         "ghcr.io/guiyomh/features/vim": {},

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
     "name": "palgoviz (EXPERIMENTAL dev container)",
-    "image": "mcr.microsoft.com/devcontainers/python:0-3.11-bookworm",
+    "image": "mcr.microsoft.com/devcontainers/python:1-3.11-bookworm",
     "features": {
         "ghcr.io/devcontainers/features/powershell:1": {},
         "ghcr.io/guiyomh/features/vim": {},


### PR DESCRIPTION
I'm not sure if the Python image for bookworm is actually published yet. As always with a major change to the dev container configuration, this needs to be manually tested before merging.