### PR TITLE
Use new-style config key for markdownlint

### DIFF
--- a/.github/workflows/markdown.yml
+++ b/.github/workflows/markdown.yml
@@ -25,7 +25,5 @@ jobs:
       - name: Markdown Lint
         uses: DavidAnson/markdownlint-cli2-action@v11
         with:
-          command: config
-          globs: |
-            .github/workflows/.markdownlint.json
-            **/*.md
+          config: '.github/workflows/.markdownlint.json'
+          globs: '**/*.md'


### PR DESCRIPTION
Instead of the now-deprecated command key.