### PR TITLE
Update CORS url_end_pattern for port forwarding

### DIFF
--- a/.devcontainer/postStart
+++ b/.devcontainer/postStart
@@ -28,7 +28,7 @@ readonly config_path=~/.jupyter/jupyter_lab_config.py
 readonly auto_comment='# postStart generated'
 
 # Python regex for the end of a permitted URL, when the beginning is also okay.
-readonly url_end_pattern='-[89][0-9]{3}\.preview\.app\.github\.dev'
+readonly url_end_pattern='-[89][0-9]{3}\.(?:preview\.)?app\.github\.dev'
 
 in_codespace() {
     # TODO: Find a more reliable way to check if we are running in a codespace.


### PR DESCRIPTION
https://github.blog/changelog/2023-07-14-codespaces-port-forwarding-domain-name-updates/

This just makes it work both with the current `preview` subdomain, which will be removed shortly, and without it. By itself, this should be sufficient to ensure compatibility with the GitHub change at the end of the month. However, it would be best to eventually refactor the code to accept an arbitrary domain in a way that both continues to be clear and avoids characters from the domain (such as `.`) being interpreted as regex metacharacters, and using the `GITHUB_CODESPACES_PORT_FORWARDING_DOMAIN` environment variable. This can be done with `re.escape` in Python, but some refactoring should probably be done first. This PR doesn't make any such changes.