### PR TITLE
Revert "Have Dependabot group Python dependencies (#158)"

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,9 +7,6 @@ updates:
     allow:
       - dependency-type: all
     open-pull-requests-limit: 20
-    groups:
-      python-dependencies:
-        patterns: ['*']
 
   - package-ecosystem: github-actions
     directory: '/'


### PR DESCRIPTION
It's not finding all or even most of the dependencies that can be updated, and automatic rebasing is failing. As noted in #158, the feature is experimental. See https://github.com/EliahKagan/palgoviz/pull/163#issuecomment-1659583326 for where automatic rebasing failed.

This reverts commit f431cfef226401eb375dbbe4a35979f5ba030a13.