### PR TITLE
Revert "Revert "Have Dependabot group Python dependencies (#158)""

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,9 @@ updates:
     allow:
       - dependency-type: all
     open-pull-requests-limit: 20
+    groups:
+      python-dependencies:
+        patterns: ['*']
 
   - package-ecosystem: github-actions
     directory: '/'


### PR DESCRIPTION
Now that the `groups` feature is considered stable, reenable it.

Reverts EliahKagan/palgoviz#165