### PR TITLE
Add old Rainbow Brackets extension to dev container

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -12,6 +12,7 @@
     "customizations": {
         "vscode": {
             "extensions": [
+                "2gua.rainbow-brackets",
                 "alefragnani.numbered-bookmarks",
                 "bierner.markdown-preview-github-styles",
                 "eamodio.gitlens",


### PR DESCRIPTION
Because VS Code's bracket pair colorization feature doesn't apply inside docstrings, and palgoviz has a lot of doctests whose clarity is improved by colorizing nested matching pairs of parentheses, square brackets, and curly braces.

References:

- [How can I get bracket pair colorization inside strings in VS Code?](https://stackoverflow.com/questions/71093558/how-can-i-get-bracket-pair-colorization-inside-strings-in-vs-code) (Stack Overflow)
- https://github.com/microsoft/vscode/issues/146453
- https://github.com/tfallon0/hiss/pull/10 (has more information on involved tradeoffs)