### PR TITLE
Tweak wording in using-notebooks

### DIFF
--- a/doc/using-notebooks.md
+++ b/doc/using-notebooks.md
@@ -82,7 +82,7 @@ notebook), JupyterLab heeds the `raises-exception` cell tag, printing a
 traceback but continuing execution with the next cell. In contrast, the
 `vscode-jupyter` extension does not yet do so.
 
-Eventually this will be fully fixed in `vscode-jupyter`, at which point VS Code
+Eventually this may be fully fixed in `vscode-jupyter`, at which point VS Code
 may become the best way to work with the notebooks in this project. This is
 related to
 [microsoft/vscode-jupyter#11441](https://github.com/microsoft/vscode-jupyter/issues/11441).


### PR DESCRIPTION
Adding raises-exception support may be out of scope for vscode-jupyter due to lack of widespread interest in the feature. This slightly rewords the second on VS Code to avoid falsely implying that the project has committed to adding raises-exception support or that it will necessarily be added.

Further refinement may be possible in the future, but I'm doing this small rewording now to avoid potentially confusing inaccuracy.