### PR TITLE
Revert "Tweak wording in using-notebooks"

### DIFF
--- a/doc/using-notebooks.md
+++ b/doc/using-notebooks.md
@@ -82,7 +82,7 @@ notebook), JupyterLab heeds the `raises-exception` cell tag, printing a
 traceback but continuing execution with the next cell. In contrast, the
 `vscode-jupyter` extension does not yet do so.
 
-Eventually this may be fully fixed in `vscode-jupyter`, at which point VS Code
+Eventually this will be fully fixed in `vscode-jupyter`, at which point VS Code
 may become the best way to work with the notebooks in this project. This is
 related to
 [microsoft/vscode-jupyter#11441](https://github.com/microsoft/vscode-jupyter/issues/11441).


### PR DESCRIPTION
It looks like the feature is being added to vscode-jupyter! This
reverts the wording since the old wording turns out more accurate,
but I'll want to update this again once I've checked the details
and (if available) tried out the feature.

Reverts EliahKagan/palgoviz#193